### PR TITLE
Display gap in benchmark results

### DIFF
--- a/bench/solve.py
+++ b/bench/solve.py
@@ -187,7 +187,7 @@ def _solve(
         sol = read_solution(bks_loc, data)
         cost_eval = CostEvaluator([0] * data.num_load_dimensions, 0, 0)
         bks = cost_eval.cost(sol)
-        gap = (result.cost() - bks) / bks * 100
+        gap = 100 * (result.cost() - bks) / bks
 
     return SolveResult(
         instance_name,


### PR DESCRIPTION
Part of #2. 


Without BKS (default)

```sh
poetry run bench solve instances/VRPTW/C1_10_1.vrp --seed 0 --max_runtime 0.2 --num_procs 8                                  

Instance  OK  Obj.     Iters. (#)  Time (s)
--------  --  -------  ----------  --------
 C1_10_1   Y  44932.0           4     0.209

     Avg. objective: 44932
    Avg. iterations: 4
      Avg. run-time: 0.21s
       Total not OK: 0
```

With BKS will compute gaps and display the gap.

```sh
poetry run bench solve instances/CVRP/*.vrp --solutions instances/CVRP/*.sol --seed 0 --max_runtime 0.1 --num_procs 8

Instance     OK  Obj.       Iters. (#)  Time (s)  Gap (%)
-----------  --  ---------  ----------  --------  -------
X-n1001-k43   Y    78397.0           1     0.346     8.35
...
 X-n979-k58   Y   124835.0           1     0.382     4.92

     Avg. objective: 114569
    Avg. iterations: 3
      Avg. run-time: 0.16s
       Total not OK: 0
           Avg. gap: 50.76%
```

This will result in a segfault and consequently `BrokenProcessPool` error because the instance/solutions are not matched, so the instance data does not correspond to the solution.
```sh
 poetry run bench solve instances/CVRP/X-n101-k25.vrp instances/CVRP/X-n1001-k43.vrp --solutions instances/CVRP/X-n1001-k43.sol instances/CVRP/X-n101-k25.sol --seed 0 --max_runtime 0.1 --num_procs 8
```